### PR TITLE
추가된 기능

### DIFF
--- a/Assets/Scene/DITrackingTest.unity
+++ b/Assets/Scene/DITrackingTest.unity
@@ -123,7 +123,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &161794117
+--- !u!1 &434451048
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -131,227 +131,137 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 161794118}
-  - component: {fileID: 161794119}
+  - component: {fileID: 434451050}
+  - component: {fileID: 434451049}
   m_Layer: 0
-  m_Name: Deactive_3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &161794118
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 161794117}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 803628637}
-  m_Father: {fileID: 1972992131}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &161794119
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 161794117}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3838962383e07ba46bb2130584b52a95, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maker: {fileID: 0}
---- !u!1 &253492203
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 253492205}
-  - component: {fileID: 253492204}
-  m_Layer: 0
-  m_Name: Deactive_1
+  m_Name: IWatingDI_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &253492204
+--- !u!114 &434451049
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 253492203}
+  m_GameObject: {fileID: 434451048}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3838962383e07ba46bb2130584b52a95, type: 3}
+  m_Script: {fileID: 11500000, guid: 335fbeb297132464a92c8dd87871a573, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maker: {fileID: 0}
---- !u!4 &253492205
+  prefab: {fileID: 3129668827294661139, guid: 20ed7988740c7ec49b947eeae12225c1, type: 3}
+  target: {fileID: 0}
+--- !u!4 &434451050
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 253492203}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1972992131}
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &410971402
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 410971403}
-  - component: {fileID: 410971404}
-  m_Layer: 0
-  m_Name: Deactive_2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &410971403
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 410971402}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 529176149}
-  m_Father: {fileID: 1144516110}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &410971404
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 410971402}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3838962383e07ba46bb2130584b52a95, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maker: {fileID: 0}
---- !u!1 &529176148
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 529176149}
-  - component: {fileID: 529176150}
-  m_Layer: 0
-  m_Name: Deactive_3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &529176149
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 529176148}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1155199054}
-  m_Father: {fileID: 410971403}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &529176150
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 529176148}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3838962383e07ba46bb2130584b52a95, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maker: {fileID: 0}
---- !u!1 &803628636
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 803628637}
-  - component: {fileID: 803628638}
-  m_Layer: 0
-  m_Name: Deactive_4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &803628637
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 803628636}
+  m_GameObject: {fileID: 434451048}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 161794118}
+  m_Father: {fileID: 2020851033}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &803628638
+--- !u!1 &749864815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 749864817}
+  - component: {fileID: 749864816}
+  m_Layer: 0
+  m_Name: IWatingDI_3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &749864816
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 803628636}
+  m_GameObject: {fileID: 749864815}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3838962383e07ba46bb2130584b52a95, type: 3}
+  m_Script: {fileID: 11500000, guid: 335fbeb297132464a92c8dd87871a573, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maker: {fileID: 0}
+  prefab: {fileID: 3129668827294661139, guid: 20ed7988740c7ec49b947eeae12225c1, type: 3}
+  target: {fileID: 0}
+--- !u!4 &749864817
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 749864815}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 788381079}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &788381077
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 788381079}
+  - component: {fileID: 788381078}
+  m_Layer: 0
+  m_Name: IWatingDI_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &788381078
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788381077}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 335fbeb297132464a92c8dd87871a573, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prefab: {fileID: 3129668827294661139, guid: 20ed7988740c7ec49b947eeae12225c1, type: 3}
+  target: {fileID: 0}
+--- !u!4 &788381079
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788381077}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 749864817}
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &897030933
 GameObject:
   m_ObjectHideFlags: 0
@@ -446,156 +356,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &1144516108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1144516110}
-  - component: {fileID: 1144516109}
-  - component: {fileID: 1144516111}
-  m_Layer: 0
-  m_Name: Deactive
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &1144516109
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1144516108}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3838962383e07ba46bb2130584b52a95, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maker: {fileID: 0}
---- !u!4 &1144516110
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1144516108}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 410971403}
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1144516111
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1144516108}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bc68837e7d0a8a6448a1e4ff7bd054f7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &1155199053
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1155199054}
-  - component: {fileID: 1155199055}
-  m_Layer: 0
-  m_Name: Deactive_4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &1155199054
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1155199053}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 529176149}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1155199055
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1155199053}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3838962383e07ba46bb2130584b52a95, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maker: {fileID: 0}
---- !u!1 &1232672447
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1232672449}
-  - component: {fileID: 1232672448}
-  m_Layer: 0
-  m_Name: RuntimeWIMaker_1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &1232672448
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1232672447}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 711f5b6bfa3db274d8e8b25cb1b73088, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  testBehaviour1: {fileID: 8469429136206652506, guid: bc327e7331cfc9d42841a7525a5d9186, type: 3}
-  testBehaviour2: {fileID: 3129668827294661139, guid: 20ed7988740c7ec49b947eeae12225c1, type: 3}
---- !u!4 &1232672449
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1232672447}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1335953353
 GameObject:
   m_ObjectHideFlags: 0
@@ -771,52 +531,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1972992130
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1972992131}
-  - component: {fileID: 1972992132}
-  m_Layer: 0
-  m_Name: Deactive_3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &1972992131
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1972992130}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 161794118}
-  m_Father: {fileID: 253492205}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1972992132
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1972992130}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3838962383e07ba46bb2130584b52a95, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maker: {fileID: 0}
 --- !u!1 &2020851032
 GameObject:
   m_ObjectHideFlags: 0
@@ -828,7 +542,7 @@ GameObject:
   - component: {fileID: 2020851033}
   - component: {fileID: 2020851034}
   m_Layer: 0
-  m_Name: RuntimeWIMaker
+  m_Name: IWatingDI
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -845,7 +559,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 434451050}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -858,8 +573,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 2020851032}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 711f5b6bfa3db274d8e8b25cb1b73088, type: 3}
+  m_Script: {fileID: 11500000, guid: 335fbeb297132464a92c8dd87871a573, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  testBehaviour1: {fileID: 8469429136206652506, guid: bc327e7331cfc9d42841a7525a5d9186, type: 3}
-  testBehaviour2: {fileID: 3129668827294661139, guid: 20ed7988740c7ec49b947eeae12225c1, type: 3}
+  prefab: {fileID: 3129668827294661139, guid: 20ed7988740c7ec49b947eeae12225c1, type: 3}
+  target: {fileID: 0}

--- a/Assets/Scene/DITrackingTest.unity.meta
+++ b/Assets/Scene/DITrackingTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b76f2eaf4c0475d44af599dd803b6e37
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TestScripts/TestBehaviour1.cs
+++ b/Assets/TestScripts/TestBehaviour1.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
-using WIFramework.Core;
+using WIFramework;
 
 public class TestBehaviour1 : WIBehaviour
 {

--- a/Assets/TestScripts/TestBehaviour2.cs
+++ b/Assets/TestScripts/TestBehaviour2.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
-using WIFramework.Core;
+using WIFramework;
 
-public class TestBehaviour2 : WIBehaviour
+public class TestBehaviour2 : SingleBehaviour
 {
     public override void Initialize()
     {

--- a/Assets/TestScripts/Test_AutoCreateWIManager.cs
+++ b/Assets/TestScripts/Test_AutoCreateWIManager.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using WIFramework.Core;
+using WIFramework;
 
 public class Test_AutoCreateWIManager : WIBehaviour
 { }

--- a/Assets/TestScripts/Test_GetKey.cs
+++ b/Assets/TestScripts/Test_GetKey.cs
@@ -1,7 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using WIFramework.Core;
+using WIFramework;
 
 public class Test_GetKey : WIBehaviour, IGetKey
 {

--- a/Assets/TestScripts/Test_GetKeyDown.cs
+++ b/Assets/TestScripts/Test_GetKeyDown.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using WIFramework.Core;
+using WIFramework;
 
 public class Test_GetKeyDown : WIBehaviour, IGetKeyDown
 {

--- a/Assets/TestScripts/Test_GetKeyUp.cs
+++ b/Assets/TestScripts/Test_GetKeyUp.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using WIFramework.Core;
+using WIFramework;
 
 public class Test_GetKeyUp : WIBehaviour, IGetKeyUp
 {

--- a/Assets/TestScripts/Test_Image.cs
+++ b/Assets/TestScripts/Test_Image.cs
@@ -1,7 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using WIFramework.Core;
+using WIFramework;
 
 public class Test_Image : WIBehaviour
 {

--- a/Assets/TestScripts/Test_InjectTest.cs
+++ b/Assets/TestScripts/Test_InjectTest.cs
@@ -1,9 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 using UnityEngine.UI;
-using WIFramework.Core;
-
+using WIFramework;
 public class Test_InjectTest : WIBehaviour
 {
     public Test_Player player;

--- a/Assets/TestScripts/Test_Player.cs
+++ b/Assets/TestScripts/Test_Player.cs
@@ -1,8 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using WIFramework.Core;
-
+using WIFramework; 
 public class Test_Player : SingleBehaviour
 {
 }

--- a/Assets/TestScripts/Test_Regist.cs
+++ b/Assets/TestScripts/Test_Regist.cs
@@ -1,7 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using WIFramework.Core;
+using WIFramework;
+
 public class Test_Regist : WIBehaviour
 {
 }

--- a/Assets/TestScripts/Test_RuntimeWIMaker.cs
+++ b/Assets/TestScripts/Test_RuntimeWIMaker.cs
@@ -1,20 +1,15 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using WIFramework.Core;
-using WIFramework.Core.Manager;
-
+using WIFramework; 
 public class Test_RuntimeWIMaker : SingleBehaviour, IGetKeyDown
 {
     public WIBehaviour testBehaviour1;
     public WIBehaviour testBehaviour2;
+
     public void GetKey(KeyCode key)
     {
         if (key == KeyCode.Q)
             WIManager.Instantiate(testBehaviour1);
         if (key == KeyCode.W)
             WIManager.Instantiate(testBehaviour2);
-
     }
-
 }

--- a/Assets/TestScripts/Test_SingleBehaviour.cs
+++ b/Assets/TestScripts/Test_SingleBehaviour.cs
@@ -1,5 +1,4 @@
-using WIFramework.Core;
-using WIFramework.Util;
+using WIFramework;
 
 public class Test_SingleBehaviour : SingleBehaviour
 {

--- a/Assets/TestScripts/Test_WatingDI.cs
+++ b/Assets/TestScripts/Test_WatingDI.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using WIFramework;
+
+public class Test_WatingDI : WIBehaviour, IGetKeyDown
+{
+    public WIBehaviour prefab;
+    public TestBehaviour2 target;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        Debug.Log($"I Wating DI...");
+    }
+
+    public void GetKey(KeyCode key)
+    {
+        if(key == KeyCode.A)
+        {
+            WIManager.Instantiate(prefab);
+        }
+    }
+}

--- a/Assets/TestScripts/Test_WatingDI.cs.meta
+++ b/Assets/TestScripts/Test_WatingDI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 335fbeb297132464a92c8dd87871a573
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WIFramework/Scripts/Core/Behaviour/SingleBehaviour.cs
+++ b/Assets/WIFramework/Scripts/Core/Behaviour/SingleBehaviour.cs
@@ -1,7 +1,4 @@
-﻿using WIFramework.Core.Manager;
-using WIFramework.Util;
-
-namespace WIFramework.Core
+﻿namespace WIFramework
 {
     /// <summary>
     /// WIManager 에서 관리하는 Singleton 클래스.

--- a/Assets/WIFramework/Scripts/Core/Behaviour/TrashBehaviour.cs
+++ b/Assets/WIFramework/Scripts/Core/Behaviour/TrashBehaviour.cs
@@ -1,7 +1,8 @@
-﻿namespace WIFramework.Core.Behaviour
+﻿namespace WIFramework
 {
     public class TrashBehaviour : WIBehaviour
     {
         public string prevBehaviourType;
+        public SingleBehaviour originBehaviour;
     }
 }

--- a/Assets/WIFramework/Scripts/Core/Behaviour/WIBehaviour.cs
+++ b/Assets/WIFramework/Scripts/Core/Behaviour/WIBehaviour.cs
@@ -1,21 +1,17 @@
 ﻿using UnityEngine;
-using System.Collections.Generic;
-using UnityEngine.EventSystems;
-using WIFramework.Util;
-using WIFramework.UI;
-using System.Linq;
-using System;
-using UnityEngine.Pool;
-using WIFramework.Core.Manager;
 
-namespace WIFramework.Core
+namespace WIFramework
 {
-    public class WIBehaviour : MonoBehaviour
+    public partial class WIBehaviour : MonoBehaviour
     {
         public virtual void Initialize()
         {
         }
 
+        private void OnDestroy()
+        {
+            WIManager.Unregist(this);
+        }
         #region Action Methods
         public virtual void Active()
         {

--- a/Assets/WIFramework/Scripts/Core/Interface/IKeyboardActor.cs
+++ b/Assets/WIFramework/Scripts/Core/Interface/IKeyboardActor.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace WIFramework.Core
+namespace WIFramework
 {
     public interface IKeyboardActor
     {
@@ -12,8 +12,5 @@ namespace WIFramework.Core
     public interface IGetKey : IKeyboardActor
     {
     }
-    /// <summary>
-    /// 2022-11-23. UniRx 도입 고민중
-    /// </summary>
     public interface IGetKeyUp: IKeyboardActor { }
 }

--- a/Assets/WIFramework/Scripts/Core/Wtil.cs
+++ b/Assets/WIFramework/Scripts/Core/Wtil.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.EventSystems;
-using WIFramework.UI;
-using WIFramework.Core;
-using WIFramework.Core.Manager;
+﻿using System.Collections.Generic;
 using UnityEditor;
+using UnityEngine;
 
-namespace WIFramework.Util
+namespace WIFramework
 {
     public static class Wtil
     {
@@ -26,6 +21,29 @@ namespace WIFramework.Util
             wiManager.gameObject.name = "WIManager";
         }
 #endif
+        /// <summary>
+        /// 하위의 모든(Deactive포함) child를 순회하며 T Type의 컴포넌트가 붙어있는지 검사하고, 있다면 container를 통해 내보낸다.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="root"></param>
+        /// <param name="container"></param>
+        public static void Search<T>(this Transform root, ref List<T> container)
+        {
+            if (root.TryGetComponents<T>(out var value))
+            {
+                container.AddRange(value);
+            }
+            var childCount = root.childCount;
+            for (int i = 0; i < childCount; ++i)
+            {
+                Search(root.GetChild(i), ref container);
+            }
+        }
+        public static bool TryGetComponents<T>(this Transform root, out T[] result)
+        {
+            result = root.GetComponents<T>();
+            return result.Length > 0;
+        }
         public static T2[] ArrayConvertor<T, T2>(T[] origin) where T : WIBehaviour where T2 : WIBehaviour
         {
             T2[] result = new T2[origin.Length];

--- a/Assets/WIFramework/Scripts/UITool/UISimpleAnimator.cs
+++ b/Assets/WIFramework/Scripts/UITool/UISimpleAnimator.cs
@@ -1,7 +1,5 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using WIFramework.Util;
 using static WIFramework.Util.EasingFunction;
 
 namespace WIFramework.UI


### PR DESCRIPTION
Search<T>(this Transform root) : root의 하위의 모든 child에서 T를 검색한다. TryGetComponents<T>(this Transform root, out T[] result) : root에 부착되어있는 T type Component를 검색한다. TrashBehaviour의 원본 표시.
WIManager.Unregist : 완전히 해지된 WIBehaviour들에 대해 참조오류가 발생하지 않도록 해준다.

업데이트된 기능
같은 GameObject 에 붙은 모든 WIBehaviour를 인식할수 있도록 수정
WIManager의 WiRegist 과정을 개선
RuntimeRegist : 런타임 중에도 WIBehaviour 들의 정상적인 초기화를 도와줄수 있게 되었음.

수정된 것들
namespace 간소화 : 기존 namespace가 너무 세분화 되어있어서 using이 너무 많이 필요함.그래서 줄임.
IKeyboardActor : 키조합이 되지 않던 문제 수정